### PR TITLE
fix: Stats endpoint now shows Artist profile count

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3637,10 +3637,9 @@ def public_overview_stats():
         return jsonify({
             'counts': {
                 'artworks': total_artworks,
-                # Homepage shows role-based artists (artist-guest users)
-                'artists': artist_role_count,
+                # Homepage shows Artist profile count (matches /artists page)
+                'artists': total_artists,
                 'artist_users': artist_role_count,
-                'artists_db': total_artists,
                 'photos': total_photos
             }
         }), 200

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -29,7 +29,7 @@
       <div class="stat-label">Artworks</div>
     </div>
     <div class="stat-card">
-      <div class="stat-value">{data.stats.artistUsers ?? data.stats.totalArtists ?? 0}</div>
+      <div class="stat-value">{data.stats.totalArtists ?? 0}</div>
       <div class="stat-label">Artists</div>
     </div>
     <div class="stat-card">


### PR DESCRIPTION
Changed /api/stats/overview to return Artist table count instead of role-based user count. This makes the home page 'Artists' stat consistent with the /artists page which shows actual Artist profile records.